### PR TITLE
Fix for shutdown crash

### DIFF
--- a/Source/ThirdParty/NetImguiLib/Source/Private/NetImgui_NetworkUE4.cpp
+++ b/Source/ThirdParty/NetImguiLib/Source/Private/NetImgui_NetworkUE4.cpp
@@ -95,6 +95,9 @@ SocketInfo* ListenConnect(SocketInfo* pListenSocket)
 
 	std::lock_guard<std::mutex> listen_socket_lock(listen_socket_mutex);
 
+	if (pListenSocket->mpSocket == nullptr)
+		return nullptr;
+
 	FSocket* pNewSocket = pListenSocket->mpSocket->Accept(FString("netImgui"));
 	if (pNewSocket)
 	{

--- a/Source/ThirdParty/NetImguiLib/Source/Private/NetImgui_NetworkUE4.cpp
+++ b/Source/ThirdParty/NetImguiLib/Source/Private/NetImgui_NetworkUE4.cpp
@@ -8,10 +8,10 @@
 #include "SocketSubsystem.h"
 #include "Sockets.h"
 
+static std::mutex listen_socket_mutex;
+
 namespace NetImgui { namespace Internal { namespace Network 
 {
-
-std::mutex listen_socket_mutex;
 
 struct SocketInfo
 {


### PR DESCRIPTION
It was possible for module shutdown to delete a SocketInfo instance that is being used by the CommunicationsHost thread. This is a very simple, heavy handed and partial fix to that issue.